### PR TITLE
Fix CI: build test binaries from correct directory

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,13 +48,14 @@ jobs:
       run: cargo build --release --verbose
 
     - name: Build test binaries
-      run: cargo build --release -p ollama_simulator --verbose
+      run: cargo build --release --verbose
+      working-directory: ./test/ollama_simulator
 
     - name: Run unit tests
       run: cargo test --verbose
 
     - name: Run integration tests
-      run: cargo run --release --bin load_balancer_test
+      run: ./target/release/load_balancer_test
       working-directory: ./test/ollama_simulator
 
   # Note for Windows users:


### PR DESCRIPTION
The ollama_simulator package is not in the main workspace, so we need to build it from its own directory (test/ollama_simulator/).

https://claude.ai/code/session_01QavpyG6PHPbUYC5uD3zX3H